### PR TITLE
Switch site font to University Roman Bold

### DIFF
--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -16,13 +16,14 @@ const GlobalStyle = createGlobalStyle`
 
   body {
     margin: 0;
-    font-family: 'Quicksand', 'Inter', 'Open Sans', sans-serif;
+    font-family: 'University Roman', serif;
+    font-weight: bold;
     background: var(--white);
     color: var(--dark-grey);
   }
 
   h1, h2, h3 {
-    font-weight: 600;
+    font-weight: bold;
   }
 `;
 
@@ -53,10 +54,8 @@ const Layout = ({ children }) => (
       `,
         }}
       />
-      <link rel="preconnect" href="https://fonts.googleapis.com" />
-      <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="true" />
       <link
-        href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&display=swap"
+        href="https://fonts.cdnfonts.com/css/university-roman"
         rel="stylesheet"
       />
     </Helmet>


### PR DESCRIPTION
## Summary
- Use University Roman Bold as the site's global font
- Load University Roman stylesheet

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894d84cdbd0832f87cf6e565c98ef33