### PR TITLE
Configure sitemap and robots for search engines

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -20,5 +20,6 @@ module.exports = {
         path: `${__dirname}/images`,
       },
     },
+    'gatsby-plugin-sitemap',
   ],
 };

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.ttowntask.com/sitemap-index.xml


### PR DESCRIPTION
## Summary
- Enable Gatsby sitemap generation via `gatsby-plugin-sitemap`
- Add `robots.txt` with sitemap reference for search engines

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6894f79c18b8832fbe47cc5c55a9e093